### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/Collections.php
+++ b/src/Collections.php
@@ -54,7 +54,7 @@ class Collections extends Plugin
         parent::init();
         self::$plugin = $this;
 
-        Craft::$app->view->twig->addExtension(new CollectionsTwigExtension());
+        Craft::$app->view->registerTwigExtension(new CollectionsTwigExtension());
 
         Event::on(
             CraftVariable::class,


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.