### PR TITLE
Move to `illuminate/collections`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "superbig/craft3-collections",
     "description": "Use Laravel Collections in Craft",
     "type": "craft-plugin",
-    "version": "2.0.4",
+    "version": "3.0.0",
     "keywords": [
         "craft",
         "cms",
@@ -23,7 +23,7 @@
     ],
     "require": {
         "craftcms/cms": "^3.0.0-RC1",
-        "tightenco/collect": "^5.8"
+        "illuminate/collections": "^8.71.0"
     },
     "repositories": [
         {


### PR DESCRIPTION
@sjelfull It seems like you’ve already got the right namespaces in play.

This PR is just to swap the Composer dependency and bump a major version.

In my limited testing this installs and works with PHP 8 (whereas Tightenco’s fails at both).